### PR TITLE
Stop deploying after master builds on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,3 @@
 test:
   override:
     - bundle exec rspec
-
-deployment:
-  production:
-    branch: master
-    commands:
-      - "git push git@heroku.com:as-lion-api.git HEAD:master"
-      - "heroku run rake db:migrate --app as-lion-api"
-      - "heroku restart --app as-lion-api"


### PR DESCRIPTION
# What's up
Way back when we used to deploy using deploy hook on CI. Since the advent of heroku's Github integration, we have moved to having heroku grab the build itself.

# What this does
Removes `circle.yml` file that instructs CircleCI to deploy to master.