### PR TITLE
Explicitly define web process in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bundle exec sidekiq


### PR DESCRIPTION
# What's up
There is no web process defined in the Procfile. When Heroku detects a ruby app, it automatically uses a standard default web process if none is defined. But the addition of the migration buildpack seems to have confused it.

Before

![screenshot 2015-12-07 11 47 36](https://cloud.githubusercontent.com/assets/5182637/11633303/9656ab2e-9cd8-11e5-8f0f-d6871372e955.png)

After

![screenshot 2015-12-07 11 47 50](https://cloud.githubusercontent.com/assets/5182637/11633312/9cc6c458-9cd8-11e5-8afd-a0b1a238dda9.png)
