### PR TITLE
Refactor /api/stats endpoint to receive category parameter

### DIFF
--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -3,9 +3,29 @@ module Api
     before_action :authenticate!
 
     def index
-      @users = User.all
+      case params[:category]
+      when "pull_requests"
+        @stats = PullRequest.all.group("user_id").count
+      when "reviews"
+        @stats = PullRequestReview.all.group("user_id").count
+      when "additions"
+        @stats = PullRequest.all.group("user_id").sum(:number_of_additions)
+      when "deletions"
+        @stats = PullRequest.all.group("user_id").sum(:number_of_deletions)
+      when "badges"
+        @stats = Badge.all.group("user_id").count
+      end
 
-      render json: @users, each_serializer: StatsSerializer, root: 'stats'
+      @stats = @stats.map do |key, value|
+        {
+          "id" => key,
+          "avatar_url" => User.find(key).avatar_url,
+          "nickname" => User.find(key).nickname,
+          "count" => value
+        }
+      end
+
+      render json: @stats, each_serializer: StatsSerializer, root: 'stats'
     end
   end
 end

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -14,6 +14,8 @@ module Api
         @stats = PullRequest.all.group("user_id").sum(:number_of_deletions)
       when "badges"
         @stats = Badge.all.group("user_id").count
+      else
+        @stats = []
       end
 
       @stats = @stats.map do |key, value|

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -19,10 +19,11 @@ module Api
       end
 
       @stats = @stats.map do |key, value|
+        user = User.find(key)
         {
           "id" => key,
-          "avatar_url" => User.find(key).avatar_url,
-          "nickname" => User.find(key).nickname,
+          "avatar_url" => user.avatar_url,
+          "nickname" => user.nickname,
           "count" => value
         }
       end

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -3,19 +3,18 @@ module Api
     before_action :authenticate!
 
     def index
-      case params[:category]
-      when "pull_requests"
-        @stats = PullRequest.all.group("user_id").count
-      when "reviews"
-        @stats = PullRequestReview.all.group("user_id").count
-      when "additions"
-        @stats = PullRequest.all.group("user_id").sum(:number_of_additions)
-      when "deletions"
-        @stats = PullRequest.all.group("user_id").sum(:number_of_deletions)
-      when "badges"
-        @stats = Badge.all.group("user_id").count
-      else
-        @stats = []
+      @stats = case params[:category]
+        when "pull_requests"
+          PullRequest.all.group("user_id").count
+        when "reviews"
+          PullRequestReview.all.group("user_id").count
+        when "additions"
+          PullRequest.all.group("user_id").sum(:number_of_additions)
+        when "deletions"
+          PullRequest.all.group("user_id").sum(:number_of_deletions)
+        when "badges"
+          Badge.all.group("user_id").count
+        else []
       end
 
       @stats = @stats.map do |key, value|

--- a/app/serializers/stats_serializer.rb
+++ b/app/serializers/stats_serializer.rb
@@ -1,23 +1,20 @@
-class StatsSerializer < UserSerializer
-  attributes :pull_requests_count, :number_of_additions, :number_of_deletions, :pull_request_reviews_count, :badges_count
+class StatsSerializer < ActiveModel::Serializer
+  attributes :id, :avatar_url, :nickname, :count
 
-  def pull_requests_count
-    object.pull_requests.count
+  def id
+    object["id"]
   end
 
-  def pull_request_reviews_count
-    object.pull_request_reviews.count
+  def avatar_url
+    object["avatar_url"]
   end
 
-  def number_of_additions
-    object.pull_requests.sum(:number_of_additions)
+  def nickname
+    object["nickname"]
   end
 
-  def number_of_deletions
-    object.pull_requests.sum(:number_of_deletions)
+  def count
+    object["count"]
   end
 
-  def badges_count
-    object.badges.count
-  end
 end


### PR DESCRIPTION
# What's up
Currently, the `/api/stats` endpoint returns all stats under encapsulated in a user object and the payload looks thus:

```json
stats: [
  {
    "id": "1",
    "avatar_url": "http://www.example.org/picture1.jpg",
    "nickname": "octocat1",
    "pullRequestCount": 112,
    "pullRequestReviewsCount": 5,
    "additionsCount": 1223,
    "deletionsCount": 2342,
    "badgesCount": 3
  },
  {
    "id": "2",
    "avatar_url": "http://www.example.org/picture2.jpg",
    "nickname": "octocat2",
    "pullRequestCount": 467,
    "pullRequestReviewsCount": 122,
    "additionsCount": 51223,
    "deletionsCount": 24342,
    "badgesCount": 23
  },
  ...
]
```

We would prefer to have the endpoint respond dynamically to the request `/api/stats/badges` with the corresponding payload:

```json
stats: [
  {
    "id": "1",
    "avatar_url": "http://www.example.org/picture1.jpg",
    "nickname": "octocat1",
    "count": 3
  },
  {
    "id": "2",
    "avatar_url": "http://www.example.org/picture2.jpg",
    "nickname": "octocat2",
    "count": 23
  },
  ...
]
```

# What this does
- Refactors `Api::StatsController` to query the database based on the value in the `category` parameter.
- Refactors `StatsSerializer` to no longer inherit from `UserSerializer`.