### PR TITLE
Actually check for expired tokens and create new ones

### DIFF
--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -11,7 +11,7 @@ module Api
       user = User.find_or_create_from_oauth(user_data, token.access_token)
 
       if user.present? && user.persisted?
-        render json: user.access_tokens.first_or_create
+        render json: user.access_tokens.active.first_or_create
       else
         render json: { errors: user.errors }, status: :unprocessable_entity
       end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -20,11 +20,11 @@ class AccessToken < ActiveRecord::Base
     return unless request.authorization
 
     bearer_token = request.authorization.gsub(/\ABearer /, '')
-    find_by(access_token: bearer_token)
+    self.active.find_by(access_token: bearer_token)
   end
 
   private
-  
+
   def set_access_token
     return if access_token.present?
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -22,7 +22,10 @@ describe AccessToken do
   describe ".from_request" do
     it "finds access token from request authorization" do
       request = double(authorization: "Bearer ABC")
-      expect(AccessToken).to receive(:find_by).with(access_token: 'ABC')
+      active_tokens = [double(:active)]
+
+      expect(active_tokens).to receive(:find_by).with(access_token: 'ABC')
+      expect(AccessToken).to receive(:active).and_return(active_tokens)
       AccessToken.from_request(request)
     end
 


### PR DESCRIPTION
# What's up
When a user authenticates for the first time, it creates a new access_token for them and sets an expiration date on the token. Upon subsequent attempts to login, it checks that there's a non-expired token available and logs them in. If there's none, then it asks them to re-authenticate.

Currently, instead of checking against the tokens that aren't expired, we just check to see if a token exists which will always be true after the first authentication. Afterwards, it keeps granting access regardless of whether the user has a valid token or not.
