### PR TITLE
Change type of body column to text

### DIFF
--- a/db/migrate/20160222175704_change_pull_request_body_to_text.rb
+++ b/db/migrate/20160222175704_change_pull_request_body_to_text.rb
@@ -1,0 +1,9 @@
+class ChangePullRequestBodyToText < ActiveRecord::Migration
+  def up
+    change_column :pull_requests, :body, :text
+  end
+
+  def down
+    change_column :pull_requests, :body, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160219204251) do
+ActiveRecord::Schema.define(version: 20160222175704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20160219204251) do
     t.integer  "number_of_deletions"
     t.integer  "number_of_changed_files"
     t.datetime "merged_at"
-    t.string   "body"
+    t.text     "body"
   end
 
   create_table "scores", id: :uuid, default: "uuid_generate_v4()", force: true do |t|


### PR DESCRIPTION
# What's up
The body field is new, but it's resulting in these:
```
ActiveRecord::StatementInvalid (PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255) 
Feb 22 12:35:14 as-lion-api app/web.1:  : INSERT INTO "pull_requests" ("base_repo_full_name", "body", "created_at", "merged_at", "number", "number_of_additions", "number_of_changed_files", "number_of_comments", "number_of_commits", "number_of_deletions", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING "id"): 
```
which crashes the app and the points don't get assigned properly.

# What this does
Changes the field to a text instead for larger capacity.