### PR TITLE
Add +1 emoji unicode to accepted character list

### DIFF
--- a/app/models/pull_request_review.rb
+++ b/app/models/pull_request_review.rb
@@ -7,10 +7,12 @@ class PullRequestReview < ActiveRecord::Base
   validates :user, presence: true
   validate :body_must_contain_positive_signs
 
+  VALID_REVIEW_REGEX = /:\+1:|:thumbsup:|:shipit:|\u{1f44d}/
+
   private
 
   def body_must_contain_positive_signs
-    unless body.match(/:\+1:|:thumbsup:|:shipit:/)
+    unless body.match(VALID_REVIEW_REGEX)
       errors.add(:body, 'must contain positive signs')
     end
   end

--- a/spec/models/pull_request_review_spec.rb
+++ b/spec/models/pull_request_review_spec.rb
@@ -8,7 +8,7 @@ describe PullRequestReview do
 
       expect(pull_request_review.errors.full_messages).to include('Body must contain positive signs')
 
-      [':+1:', ':shipit:', ':thumbsup:'].each do |message|
+      [':+1:', ':shipit:', ':thumbsup:', '👍'].each do |message|
         pull_request_review.body = message
         pull_request_review.valid?
 


### PR DESCRIPTION
# What's up
Github changed the value they used to represent some their emojis to their unicode representation, and this included the 👍 emoji. It's value changed from `:+1:` to `u1f44d`.

This updates the review body accepted characters to include the unicode representation.