### PR TITLE
Use active users to generate github client

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,10 @@ class User < ActiveRecord::Base
   end
 
   def self.clients
-    @clients ||= User.where(nickname: ENV['USERS'].split(',')).map(&:github_client)
+    @clients ||= User.where(nickname: self.active.map(&:nickname)).map(&:github_client)
+  end
+  
+  def self.active
+    AccessToken.active.map(&:user)
   end
 end


### PR DESCRIPTION
# What's up
Github's API only allows limited operations with application authorization. To do more advanced things like read comments on a pull request, an application will have to be authorized by a user to use his/her access tokens to do those actions. Currently, we use a predetermined list of users stored in an environment variable `USERS` as the defacto users whose authorizations will be used to carry out these kinds of operations. A problem arises when one or more of those predetermined users no longer authorize the application. 

# What this does
We are moving away from using the `USERS` variable and will instead query for active access tokens which are guaranteed to be users who have most recently authorized the application.