### PR TITLE
Set config.api_only to true

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,19 +17,9 @@ module Lion
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run 'rake -D time' for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
     config.active_record.schema_format = :ruby
     # config.active_record.raise_in_transactional_callbacks = true
 
-    config.middleware.use config.session_store, config.session_options
-    config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore
+    config.api_only = true
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,19 +22,6 @@ Lion::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.public_file_server.enabled = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
-  # Version of your assets, change this if you want to expire all your assets.
-  config.assets.version = '1.0'
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx


### PR DESCRIPTION
The name of this app is lion-api, so it makes no sense why we are setting asset config details. Kill with :fire: