### PR TITLE
Prevent heroku app from maxing out connections on redis plan

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+# https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting
+:concurrency:  3


### PR DESCRIPTION
# What this does
Fixes `Redis::CommandError: ERR max number of clients reached` being raised when running a sidekiq worker as described here: https://github.com/mperham/sidekiq/issues/117