### PR TITLE
Ensure uniqueness of pull requests

### DIFF
--- a/app/controllers/api/pull_requests_controller.rb
+++ b/app/controllers/api/pull_requests_controller.rb
@@ -2,7 +2,11 @@ module Api
   class PullRequestsController < ApplicationController
     def create
       if action == 'closed'
-        PointsMarshaler.new(data: pull_request_params).marshal
+        begin
+          PointsMarshaler.new(data: pull_request_params).marshal
+        rescue ActiveRecord::RecordNotUnique => e
+          Honeybadger.notify(e, context: pull_request_params)
+        end
       end
 
       head :ok

--- a/db/migrate/20160913145500_add_unique_index_to_pull_requests.rb
+++ b/db/migrate/20160913145500_add_unique_index_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToPullRequests < ActiveRecord::Migration[5.0]
+  def change
+    add_index :pull_requests, [:base_repo_full_name, :number], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160222175704) do
+ActiveRecord::Schema.define(version: 20160913145500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20160222175704) do
     t.integer  "number_of_changed_files"
     t.datetime "merged_at"
     t.text     "body"
+    t.index ["base_repo_full_name", "number"], name: "index_pull_requests_on_base_repo_full_name_and_number", unique: true, using: :btree
   end
 
   create_table "scores", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/requests/pull_requests_spec.rb
+++ b/spec/requests/pull_requests_spec.rb
@@ -14,5 +14,19 @@ describe 'PullRequests Requests', type: :request do
       expect(pull_request).to be_present
       expect(pull_request.user).to eq(current_user)
     end
+
+    it 'does not duplicate pull requests' do
+      allow_any_instance_of(PullRequest).to receive(:comments).and_return([])
+
+      expect{
+        post api_pull_requests_path, params.to_json
+      }.to change(PullRequest, :count).by 1
+      expect(last_response.status).to eq 200
+
+      expect{
+        post api_pull_requests_path, params.to_json
+      }.to change(PullRequest, :count).by 0
+      expect(last_response.status).to eq 200
+    end
   end
 end


### PR DESCRIPTION
Pull requests should be unique, and this PR adds a database level enforcement of this uniqueness.