### PR TITLE
Honeybadger notification should happen inside PointsMarshaler

### DIFF
--- a/app/controllers/api/pull_requests_controller.rb
+++ b/app/controllers/api/pull_requests_controller.rb
@@ -2,11 +2,7 @@ module Api
   class PullRequestsController < ApplicationController
     def create
       if action == 'closed'
-        begin
-          PointsMarshaler.new(data: pull_request_params).marshal
-        rescue ActiveRecord::RecordNotUnique => e
-          Honeybadger.notify(e, context: pull_request_params)
-        end
+        PointsMarshaler.new(data: pull_request_params).marshal
       end
 
       head :ok

--- a/app/models/points_marshaler.rb
+++ b/app/models/points_marshaler.rb
@@ -16,6 +16,8 @@ class PointsMarshaler
       create_reviews(pull_request)
       pull_request
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    Honeybadger.notify(e, context: data)
   end
 
   private


### PR DESCRIPTION
`Honeybadger.notify` was being called in the rescue block around the `PointsMarshaler#marshal` call in the PullRequestsController#create action. However, the error being rescued can also occur in the sidekiq worker. So we need to put this around the actual `PullRequest#create` call that throws the expected error.