### PR TITLE
Users has been deprecated

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -5,4 +5,3 @@ ORGANIZATION_NAME=alphasights
 PORT=3000
 RACK_ENV=development
 RAILS_SECRET_KEY=secret
-USERS=


### PR DESCRIPTION
## What

Remove `USERS` from `.example-env` since it has been deprecated.