### PR TITLE
Decouple AS specific information by using the ENV

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -2,6 +2,7 @@ CLIENT_URL=http://localhost:4200
 GITHUB_APP_ID=
 GITHUB_APP_SECRET=
 ORGANIZATION_NAME=alphasights
+HEROKU_APP_NAME=as-lion-api-staging
 PORT=3000
 RACK_ENV=development
 RAILS_SECRET_KEY=secret

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'graphql'
 
 group :development do
   gem 'bullet'
+  gem 'thor-rails'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (0.19.1)
+    thor-rails (0.0.1)
+      rails
+      thor
     thread_safe (0.3.5)
     tilt (2.0.5)
     tool (0.2.3)
@@ -228,9 +231,10 @@ DEPENDENCIES
   sidekiq
   sinatra!
   skylight
+  thor-rails
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/README.md
+++ b/README.md
@@ -7,20 +7,43 @@ It rewards developers when they get shit done®.
 
 This is the API. [Here](https://github.com/alphasights/lion) you can find the web client.
 
+## Setup
+
+Clone this repository and run:
+
+```bash
+# Bundle the application
+bundle install
+
+# Copy the sample ENV
+# Update the `GITHUB_APP_ID`, `GITHUB_APP_SECRET`, `USERS` and other variables to relevant values for your organization.
+cp .example-env .env
+
+# Setup the database
+bundle exec rake db:create db:migrate
+
+# -- Optional
+# If your app is runningon heroku you can download a snapshot of the DB by setting the HEROKU_APP_NAME Env var and running:
+bundle exec thor:db:capture     # To capture a db backup on production
+bundle exec thor db:sync        # To install this backup locally on the dev database
+```
+
+## Running
+
+```bash
+rails server
+```
+
+## Testing
+
+```bash
+bundle exec rspec
+```
+
 ## Contributing
 
 - Fork this repository
-- `cp .example-env .env`
-- Update the `GITHUB_APP_ID`, `GITHUB_APP_SECRET` and `USERS` variables to relevant values.
-- `bundle install`
-- `bundle exec thor db:capture`
-- `bundle exec thor db:sync`
-
-## Running
-- `rails server`
-
-## Testing
-- `bundle exec rspec`
+- Create a PR and send it our way
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bundle exec rake db:create db:migrate
 
 # -- Optional
 # If your app is runningon heroku you can download a snapshot of the DB by setting the HEROKU_APP_NAME Env var and running:
-bundle exec thor:db:capture     # To capture a db backup on production
+bundle exec thor db:capture     # To capture a db backup on production
 bundle exec thor db:sync        # To install this backup locally on the dev database
 ```
 

--- a/lib/tasks/db.thor
+++ b/lib/tasks/db.thor
@@ -1,5 +1,8 @@
+require 'thor/rails'
+
 class Db < Thor
   include Thor::Actions
+  include Thor::Rails
 
   no_tasks do
     def database
@@ -20,13 +23,13 @@ class Db < Thor
   desc "capture", "capture production snapshot"
   def capture
     puts "Capturing production database..."
-    run('heroku pg:backups capture --app as-lion-api-staging')
+    run("heroku pg:backups capture --app #{ENV.fetch('HEROKU_APP_NAME')}")
   end
 
   desc "pull", "pull production snapshot"
   def pull
     puts "Downloading production snapshot..."
-    url = `heroku pg:backups public-url --app as-lion-api-staging`.gsub("\"", "").strip
+    url = `heroku pg:backups public-url --app #{ENV.fetch("HEROKU_APP_NAME")}`.gsub("\"", "").strip
     success = system(%{curl "#{url}" -# -o /tmp/latest.dump})
     unless success
       puts "Failed to download"


### PR DESCRIPTION
# What's up

Some of the thor utilities methods where targeting AlphaSights specific applications (`as-lion-api-staging`). I changed the code so that the ENV is used so other users can modify it to their app.

Also updated the documentation with some missing database migration steps.