### PR TITLE
Use graphql-batch to tame N+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'lograge'
 gem 'rack-protection', github: 'sinatra/rack-protection'
 gem 'rails_12factor', group: :production
 gem 'graphql'
+gem 'graphql-batch'
 
 group :development do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     graphql (0.18.1)
+    graphql-batch (0.2.4)
+      graphql (~> 0.8)
+      promise.rb (~> 0.7.0.rc2)
     honeybadger (2.6.0)
     i18n (0.7.0)
     lograge (0.4.1)
@@ -116,6 +119,7 @@ GEM
       sawyer (~> 0.7.0, >= 0.5.3)
     pg (0.18.4)
     pkg-config (1.1.7)
+    promise.rb (0.7.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -216,6 +220,7 @@ DEPENDENCIES
   factory_girl_rails!
   faker
   graphql
+  graphql-batch
   honeybadger
   lograge
   octokit

--- a/app/models/graph/loaders/find_loader.rb
+++ b/app/models/graph/loaders/find_loader.rb
@@ -1,0 +1,21 @@
+module Graph
+  module Loaders
+    class FindLoader < GraphQL::Batch::Loader
+      def initialize(model, key)
+        @model = model
+        @key = key
+      end
+
+      def perform(args)
+        model
+          .where(key => args.uniq)
+          .each { |record| fulfill(record.public_send(key), record) }
+
+        args.each { |arg| fulfill(arg, nil) unless fulfilled?(arg) }
+      end
+
+      private
+        attr_reader :model, :key
+    end
+  end
+end

--- a/app/models/graph/schema.rb
+++ b/app/models/graph/schema.rb
@@ -1,3 +1,5 @@
 module Graph
   Schema = GraphQL::Schema.new(query: Graph::QueryType)
 end
+
+Graph::Schema.query_execution_strategy = GraphQL::Batch::ExecutionStrategy

--- a/app/models/graph/score_type.rb
+++ b/app/models/graph/score_type.rb
@@ -5,6 +5,10 @@ module Graph
 
     field :id, types.ID
     field :points, types.Int
-    field :user, Graph::UserType
+    field :user, Graph::UserType do
+      resolve -> (score, _, _) do
+        Loaders::FindLoader.for(User, :id).load(score.user_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What this does
The landing page of the application queries the graph API for the weekly scores. This query also returns with the user associated with each score object. That association is causing an N+1 when it's being loaded. Using graphql-batch delays the resolution until we know all the users we want loaded at which point we ask for all of them with one DB query.

### Before
<img width="1054" alt="screenshot 2016-10-21 16 55 39" src="https://cloud.githubusercontent.com/assets/5182637/19611749/23e18e72-97b1-11e6-9ef2-f3dad8fac180.png">

### After
<img width="1278" alt="screenshot 2016-10-21 17 07 03" src="https://cloud.githubusercontent.com/assets/5182637/19611752/26c1367e-97b1-11e6-9406-92f816c666a2.png">
