### PR TITLE
Remove old score artifacts

### DIFF
--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -11,6 +11,8 @@ class Score < ApplicationRecord
   scope :for_week, ->(date) {
     where(created_at: date.beginning_of_week..date.end_of_week)
   }
+  scope :without_pr, -> { where(pull_request_id: nil) }
+  scope :without_review, -> { where(pull_request_review_id: nil) }
 
   def self.weekly_high_score(date = DateTime.now)
     self.weekly_scores(date).to_a.max_by(&:last)

--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -1,0 +1,11 @@
+namespace :data_cleanup do
+  desc "a task to remove old style scores without associated prs or reviews"
+  task remove_scores: :environment do
+    unattached_scores = Score.without_pr.without_review
+    puts "Found #{ActionController::Base.helpers.pluralize(unattached_scores.count, 'unattached score')}"
+    puts "Removing unattached scores..."
+    unattached_scores.destroy_all
+    puts "Done"
+    puts "Found #{ActionController::Base.helpers.pluralize(unattached_scores.count, 'unattached score')}"
+  end
+end


### PR DESCRIPTION
## What's up
https://github.com/alphasights/lion-api/pull/84 established that each score a user gets is associated to a scoring event (either a pull request or pull request review). After the migration to this new scheme, we're left with the old `scores` rows that are now invalid since they possess neither association.

## What this does
Adds a task that cleans up orphaned score rows.