### PR TITLE
Accept graphql variables in api controllers

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -3,10 +3,17 @@ module Api
     def execute
       result = Graph::AuthSchema.execute(
         params[:query],
+        variables: graphql_params.fetch(:variables, {}),
         context: { current_user: current_user }
       )
 
       render json: result
+    end
+
+    private
+
+    def graphql_params
+      params.permit(:query, variables: {})
     end
   end
 end

--- a/app/controllers/api/graph_controller.rb
+++ b/app/controllers/api/graph_controller.rb
@@ -5,10 +5,17 @@ module Api
     def execute
       result = Graph::Schema.execute(
         params[:query],
+        variables: graphql_params.fetch(:variables, {}),
         context: { current_user: current_user }
       )
 
       render json: result
+    end
+
+    private
+
+    def graphql_params
+      params.permit(:query, variables: {})
     end
   end
 end


### PR DESCRIPTION
Whitelist the `query` and `variables` parameters in the api/auth and api/graph controllers