### PR TITLE
Graph Query include Nested Users

### DIFF
--- a/app/controllers/api/graph_controller.rb
+++ b/app/controllers/api/graph_controller.rb
@@ -4,11 +4,7 @@ module Api
 
     def execute
       result = Graph::Schema.execute(
-<<<<<<< HEAD
         graphql_params[:query],
-=======
-        params[:query],
->>>>>>> origin/master
         variables: graphql_params.fetch(:variables, {}),
         context: { current_user: current_user }
       )

--- a/app/controllers/api/graph_controller.rb
+++ b/app/controllers/api/graph_controller.rb
@@ -4,11 +4,18 @@ module Api
 
     def execute
       result = Graph::Schema.execute(
-        params[:query],
+        graphql_params[:query],
+        variables: graphql_params.fetch(:variables, {}),
         context: { current_user: current_user }
       )
 
       render json: result
+    end
+
+    private
+
+    def graphql_params
+      params.permit(:query, variables: {})
     end
   end
 end

--- a/app/models/graph/query_type.rb
+++ b/app/models/graph/query_type.rb
@@ -53,11 +53,12 @@ module Graph
           else []
         end
 
+        users = User.where(id: stats.map(&:first))
         stats.map do |user_id, count|
           OpenStruct.new(
             id: "#{user_id}-#{arguments[:category]}",
             count: count,
-            user_id: user_id
+            user: users.find { |u| u.id == user_id }
           )
         end
       end

--- a/app/models/graph/query_type.rb
+++ b/app/models/graph/query_type.rb
@@ -27,11 +27,12 @@ module Graph
           else []
         end
 
+        users = User.where(id: scores.map(&:first))
         scores.map do |user_id, points|
           OpenStruct.new(
             id: "#{user_id}-#{arguments[:time_span]}",
             points: points,
-            user_id: user_id
+            user: users.find { |u| u.id == user_id }
           )
         end
       end

--- a/app/models/graph/query_type.rb
+++ b/app/models/graph/query_type.rb
@@ -32,6 +32,7 @@ module Graph
           OpenStruct.new(
             id: "#{user_id}-#{arguments[:time_span]}",
             points: points,
+            user_id: user_id,
             user: users.find { |u| u.id == user_id }
           )
         end
@@ -58,6 +59,7 @@ module Graph
           OpenStruct.new(
             id: "#{user_id}-#{arguments[:category]}",
             count: count,
+            user_id: user_id,
             user: users.find { |u| u.id == user_id }
           )
         end

--- a/app/models/graph/score_type.rb
+++ b/app/models/graph/score_type.rb
@@ -6,5 +6,6 @@ module Graph
     field :id, types.ID
     field :points, types.Int
     field :user_id, types.ID
+    field :user, Graph::UserType
   end
 end

--- a/app/models/graph/stats_type.rb
+++ b/app/models/graph/stats_type.rb
@@ -6,5 +6,6 @@ module Graph
     field :count, types.Int
     field :id, types.ID
     field :user_id, types.ID
+    field :user, Graph::UserType
   end
 end

--- a/app/models/graph/weekly_winning_type.rb
+++ b/app/models/graph/weekly_winning_type.rb
@@ -7,5 +7,6 @@ module Graph
     field :points, types.Int
     field :start_date, types.String
     field :winner_id, types.ID
+    field :winner, Graph::UserType
   end
 end

--- a/spec/requests/scores_spec.rb
+++ b/spec/requests/scores_spec.rb
@@ -13,7 +13,9 @@ describe 'Scores graph', type: :request do
           scores(time_span: "all_time") {
             id
             points
-            user_id
+            user {
+              id
+            }
           }
         }
       QUERY
@@ -22,11 +24,15 @@ describe 'Scores graph', type: :request do
         [{
           'id' => "#{jay.id}-all_time",
           'points' => 10,
-          'user_id' => jay.id.to_s
+          'user' => {
+            'id' => jay.id.to_s
+          }
         }, {
           'id' => "#{joe.id}-all_time",
           'points' => 5,
-          'user_id' => joe.id.to_s
+          'user' => {
+            'id' => joe.id.to_s
+          }
         }]
       )
     end

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -19,7 +19,9 @@ describe 'Stats graph', type: :request do
           stats(category: "reviews") {
             id
             count
-            user_id
+            user {
+              id
+            }
           }
         }
       QUERY
@@ -29,7 +31,9 @@ describe 'Stats graph', type: :request do
           {
             'id' => "#{user.id}-reviews",
             'count' => review_counts[user.id],
-            'user_id' => user.id.to_s
+            'user' => {
+              'id' => user.id.to_s
+            }
           }
         end
       )


### PR DESCRIPTION
### What's New
Add nested user objects to stats and scores query types, as well as weekly winning type.

Also ensure the use of our whitelisted hash ```graphql_params``` in our graph and auth controllers.