### PR TITLE
Begin retrieving Title from new Pull Requests and add to Schema

### DIFF
--- a/app/controllers/api/pull_requests_controller.rb
+++ b/app/controllers/api/pull_requests_controller.rb
@@ -20,6 +20,7 @@ module Api
       {
         user: User.where(nickname: data['user']['login']).first,
         base_repo_full_name: data['base']['repo']['full_name'],
+        title: data['title'],
         body: data['body'],
         number: data['number'],
         number_of_comments: data['comments'],

--- a/db/migrate/20180126214622_add_title_to_pull_requests.rb
+++ b/db/migrate/20180126214622_add_title_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddTitleToPullRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pull_requests, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171130230041) do
+ActiveRecord::Schema.define(version: 20180126214622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20171130230041) do
     t.integer "number_of_changed_files"
     t.datetime "merged_at"
     t.text "body"
+    t.string "title"
     t.index ["base_repo_full_name", "number"], name: "index_pull_requests_on_base_repo_full_name_and_number", unique: true
   end
 


### PR DESCRIPTION
### What's New
We want to begin pulling the actual title from Pull Requests when Lion gets updated from Github.

To do this we:
- Add title field onto the Pull Request schema via migration
- Tell the Pull Request Controller to also retrieve the additional title field


#### Next Up
- Create backfilling task to update historic data with titles from Github API