### PR TITLE
Fix Syntax for Loading Rails Environment into Task

### DIFF
--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -1,6 +1,6 @@
 namespace :backfill do
   # Bulk updates all Pull Requests with no Titles via Github API
-  task :update_pull_request_titles, :environment do |t, args|
+  task :update_pull_request_titles => :environment do |t, args|
     pull_requests_without_titles = PullRequest.where(:title => nil)
     update_count = pull_requests_without_titles.count
 


### PR DESCRIPTION
## Problem
Running task resulted in Uninitialized Constant error for the class names PullRequest and User. Problem was most likely the syntax used for loading in the rails env.