### PR TITLE
Add Title to PR Graph Type, rescue API Exceptions in Backfill

### DIFF
--- a/app/models/graph/pull_request_type.rb
+++ b/app/models/graph/pull_request_type.rb
@@ -8,6 +8,7 @@ module Graph
     field :id, types.ID
     field :name, types.String, property: :base_repo_full_name
     field :number, types.Int
+    field :title, types.String
     field :user, Graph::UserType, preload: :user
   end
 end

--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -5,8 +5,13 @@ namespace :backfill do
     update_count = pull_requests_without_titles.count
 
     pull_requests_without_titles.each do |pr|
-      response = User.global_client.pull_request(pr.base_repo_full_name, pr.number)
-      pr.update!(:title => response.title)
+      begin
+        response = User.global_client.pull_request(pr.base_repo_full_name, pr.number)
+        pr.update!(:title => response.title)
+        puts '.'
+      rescue Exception
+        puts 'x'
+      end
     end
 
     puts "Successfully updated #{update_count} Pull Requests."

--- a/spec/tasks/backfill_spec.rb
+++ b/spec/tasks/backfill_spec.rb
@@ -27,7 +27,8 @@ describe 'Backfill Tasks', type: :task do
       allow(User).to receive(:global_client) { Octokit::Client.new }
       allow_any_instance_of(Octokit::Client).to receive(:pull_request) { pull_request_response }
 
-      expect(STDOUT).to receive(:puts).with("Successfully updated 2 Pull Requests.")
+      expect(STDOUT).to receive(:puts).with('.').twice
+      expect(STDOUT).to receive(:puts).with('Successfully updated 2 Pull Requests.')
       run_rake_task
       expect(pull_request_without_title_one.reload.title).to eq 'Replaced all the commas with periods'
     end


### PR DESCRIPTION
### What's Up
Now that we are backfilling titles into our data, expose them via the Pull Request Type. Also rescue API exceptions to avoid conflicts with 'expired' repo's, and add a bit of a logging indicator.