### PR TITLE
Refactor Score Breakdown Query Type into Field under User

### DIFF
--- a/app/models/graph/query_type.rb
+++ b/app/models/graph/query_type.rb
@@ -7,15 +7,6 @@ module Graph
       resolve -> (_, _, _) { WeeklyWinning.order(start_date: :desc) }
     end
 
-    field :score_breakdowns, types[Graph::ScoreBreakdownType] do
-      argument :week, !types.Int, "The week for which we want a score breakdown (how many weeks ago)"
-      argument :user_id, !types.ID, "The user whose breakdown is being requested"
-      resolve ->(_, arguments, _) do
-        week = DateTime.now.weeks_ago(arguments[:week])
-        Score.for_week(week).where(user_id: arguments[:user_id])
-      end
-    end
-
     field :scores, types[Graph::ScoreType] do
       argument :time_span, !types.String, "The time span of the scores"
       resolve -> (_, arguments, _) do

--- a/app/models/graph/query_type.rb
+++ b/app/models/graph/query_type.rb
@@ -7,6 +7,15 @@ module Graph
       resolve -> (_, _, _) { WeeklyWinning.order(start_date: :desc) }
     end
 
+    field :score_breakdowns, types[Graph::ScoreBreakdownType] do
+      argument :week, !types.Int, "The week for which we want a score breakdown (how many weeks ago)"
+      argument :user_id, !types.ID, "The user whose breakdown is being requested"
+      resolve ->(_, arguments, _) do
+        week = DateTime.now.weeks_ago(arguments[:week])
+        Score.for_week(week).where(user_id: arguments[:user_id])
+      end
+    end
+
     field :scores, types[Graph::ScoreType] do
       argument :time_span, !types.String, "The time span of the scores"
       resolve -> (_, arguments, _) do

--- a/app/models/graph/user_type.rb
+++ b/app/models/graph/user_type.rb
@@ -7,5 +7,14 @@ module Graph
     field :id, types.ID
     field :name, types.String
     field :nickname, types.String
+
+    field :score_breakdowns, types[Graph::ScoreBreakdownType] do
+      argument :week, !types.Int, "The week for which we want a score breakdown (how many weeks ago)"
+
+      resolve ->(user, args, _) do
+        week = DateTime.now.weeks_ago(args[:week])
+        Score.for_week(week).where(user_id: user.id)
+      end
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -43,6 +43,38 @@ describe 'Users graph', type: :request do
         )
       end
     end
+
+    context 'with score breakdown arguments' do
+      it 'responds with a json representing the requested user' do
+        user = create(:user)
+        pr = create(:pull_request, { merged_at: Date.today.to_time, user: user })
+        score = create(:score, { pull_request: pr, user: user })
+
+        post api_graph_path(query: <<~QUERY)
+          query user {
+            user(id: "#{user.id}") {
+              id
+              scores: score_breakdowns(week: 0) {
+                id
+                pull_request {
+                  id
+                }
+              }
+            }
+          }
+          QUERY
+        puts JSON.parse(last_response.body)
+        expect(JSON.parse(last_response.body)['data']['user']).to eq(
+          'id' => user.id,
+          'scores' => [{
+            'id' => score.id,
+            'pull_request' => {
+              'id' => pr.id
+            }
+          }]
+        )
+      end
+    end
   end
 
   describe 'query users' do


### PR DESCRIPTION
Problem
Score breakdown query returns nothing if there are no scores for the argument time period. This is bad when we want to maintain context of the User even when no score exists.

Solution
Restructure the GraphQL schema to include the score breakdown resolution as a field off the User type that takes arguments.